### PR TITLE
Add tests, including failing test for organization

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,5 +4,11 @@ const requireStyle = require('../')
 
 test('require-style', function (t) {
   t.ok(requireStyle, 'module is require-able')
+  t.ok(requireStyle('../index.js'))
+  t.end()
+})
+
+test('self', function (t) {
+  t.ok(requireStyle('./index.js'))
   t.end()
 })


### PR DESCRIPTION
Add two tests: one to ensure that the test file can require itself and
another to ensure that it can require an organization module (which
start with `@` and contain `/`). The first tests passes but the second
fails.